### PR TITLE
[fix] disable prod env on auto-load iframe

### DIFF
--- a/tools/sidekick/aem-experimentation.js
+++ b/tools/sidekick/aem-experimentation.js
@@ -1,5 +1,30 @@
 /* eslint-disable */
 (function () {
+  function isDebugEnvironment() {
+    const { host, hostname, origin } = window.location;
+
+    return (
+      hostname === 'localhost' ||
+      hostname.endsWith('.page') ||
+      (window.hlx?.experimentation?.options?.isProd &&
+        typeof window.hlx.experimentation?.options?.isProd === 'function' &&
+        !window.hlx.experimentation?.options?.isProd()) ||
+      (window.hlx?.experimentation?.options?.prodHost &&
+        ![host, hostname, origin].includes(
+          window.hlx.experimentation?.options?.prodHost
+        )) ||
+      false
+    );
+  }
+
+  if (!isDebugEnvironment()) {
+    // eslint-disable-next-line no-console
+    console.log(
+      '[AEM Exp] Experimentation UI disabled in production environment'
+    );
+    return;
+  }
+
   let isAEMExperimentationAppLoaded = false;
   let scriptLoadPromise = null;
   let isHandlingSimulation = false;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--aem-experimentation-boilerplate--adobe.aem.live/
- After: https://main--aem-experimentation-boilerplate--adobe.aem.live/
